### PR TITLE
Restrict GitHub Actions workflow permissions to contents: read for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["master"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary
This Pull Request restricts GitHub Actions workflow permissions to `contents: read`

### Details
If permissions are not explicitly defined in a GitHub Actions workflow, the workflow inherits the default permissions configured at the GitHub Organization level. Depending on the organization settings, this may result in `contents: write` being granted.

Since the CI workflow only requires `contents: read`, this change explicitly sets the workflow permissions to `contents: read` to ensure the principle of least privilege and avoid unintentionally granting write access.

### Related Links
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token